### PR TITLE
修改拼写错误，并添加一个 BIOS 设置项

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,28 +147,30 @@ OpenCore 拥有高度的可定制化，建议先参考下面的说明使用配�
 ### BIOS 设置
 *请先确定正在使用的 BIOS 版本，[迫击炮](https://cn.msi.com/Motherboard/support/B360M-MORTAR) 7B23v16 以上，[迫击炮钛金版](https://cn.msi.com/Motherboard/support/B360M-MORTAR-TITANIUM) 7B23vA6 以上，否则请参考官方文档升级 BIOS 至最新版本（v19 & vA9 版本可用）。*<br>
 <br>
-STTINGS\高级\PCI子系统设置\Above 4G memory/Crypto Currency mining [允许]<br>
+SETTINGS\高级\PCI子系统设置\Above 4G memory/Crypto Currency mining [允许]<br>
 <br>
-STTINGS\高级\内建显示配置\设置第一显卡 [PEG]*（仅同时拥有核显及独显需要手动设置）*<br>
-STTINGS\高级\内建显示配置\集显共享内存 [64M]*（如果使用拥有核显的处理器）*<br>
-STTINGS\高级\内建显示配置\集成显卡多显示器 [允许]*（如果使用拥有核显的处理器）*<br>
+SETTINGS\高级\内建显示配置\设置第一显卡 [PEG]*（仅同时拥有核显及独显需要手动设置）*<br>
+SETTINGS\高级\内建显示配置\集显共享内存 [64M]*（如果使用拥有核显的处理器）*<br>
+SETTINGS\高级\内建显示配置\集成显卡多显示器 [允许]*（如果使用拥有核显的处理器）*<br>
 <br>
-STTINGS\高级\ACPI设置\电源 LED 灯 [双色]*（如果选择 [闪烁]，睡眠时电源灯将不断闪烁）*<br>
+SETTINGS\高级\ACPI设置\电源 LED 灯 [双色]*（如果选择 [闪烁]，睡眠时电源灯将不断闪烁）*<br>
 <br>
-STTINGS\高级\USB设置\XHCI Hand-off [允许]<br>
-STTINGS\高级\USB设置\传统USB支持 [允许]<br>
+SETTINGS\高级\整合周边设备\SATA设置\SATA模式 [AHCI模式]*（如果选择 Optane 模式则无法识别硬盘）*<br>
 <br>
-STTINGS\高级\电源管理设置\ErP Ready [允许]<br>
+SETTINGS\高级\USB设置\XHCI Hand-off [允许]<br>
+SETTINGS\高级\USB设置\传统USB支持 [允许]<br>
 <br>
-STTINGS\高级\Windows操作系统的配置\Windows 10 WHQL支持 [允许]*（开启为「纯」UEFI 模式，否则为「兼容」UEFI 模式，推荐设置为允许）*<br>
-STTINGS\高级\Windows操作系统的配置\MSI 快速开机 [禁止]<br>
-STTINGS\高级\Windows操作系统的配置\快速开机 [禁止]<br>
+SETTINGS\高级\电源管理设置\ErP Ready [允许]<br>
 <br>
-STTINGS\高级\唤醒事件设置\唤醒事件管理 [BIOS]<br>
-STTINGS\高级\唤醒事件设置\USB设备从S3/S4/S5唤醒 [允许]<br>
+SETTINGS\高级\Windows操作系统的配置\Windows 10 WHQL支持 [允许]*（开启为「纯」UEFI 模式，否则为「兼容」UEFI 模式，推荐设置为允许）*<br>
+SETTINGS\高级\Windows操作系统的配置\MSI 快速开机 [禁止]<br>
+SETTINGS\高级\Windows操作系统的配置\快速开机 [禁止]<br>
 <br>
-STTINGS\启动\启动NumLock状态 [关]*（macOS 默认可使用数字键盘，只有 macOS 的话推荐关闭）*<br>
-STTINGS\启动\启动模式选择 [UEFI]<br>
+SETTINGS\高级\唤醒事件设置\唤醒事件管理 [BIOS]<br>
+SETTINGS\高级\唤醒事件设置\USB设备从S3/S4/S5唤醒 [允许]<br>
+<br>
+SETTINGS\启动\启动NumLock状态 [关]*（macOS 默认可使用数字键盘，只有 macOS 的话推荐关闭）*<br>
+SETTINGS\启动\启动模式选择 [UEFI]<br>
 <br>
 OC(Overclocking)\CPU 特征\Intel 虚拟化技术 [允许]*（必须）*<br>
 OC(Overclocking)\CPU 特征\Intel VT-D 技术 [禁止]*（必须）*<br>


### PR DESCRIPTION
在安装和引导的时候一直无法识别到 SATA 硬盘，之后发现 BIOS 里 SATA 模式被设置成了 Optane 模式，改成 AHCI 模式就 OK 了